### PR TITLE
Bugfix: fix scorebug filtering

### DIFF
--- a/src/components/game/ScorebugGrid.jsx
+++ b/src/components/game/ScorebugGrid.jsx
@@ -12,7 +12,7 @@ const ScorebugGrid = ({ games, onPageChange, totalGames, currentPage }) => {
     };
 
     // Calculate the total number of pages
-    const totalPages = Math.ceil(totalGames / 20); // Assuming 20 items per page
+    const totalPages = Math.ceil(totalGames / 10); // Assuming 10 items per page
 
     const handlePaginationChange = (event, page) => {
         onPageChange(page - 1); // Page is 1-based, but your `filters.page` is 0-based

--- a/src/components/menu/FilterMenu.jsx
+++ b/src/components/menu/FilterMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     FormControlLabel,
     Checkbox,
@@ -22,21 +22,64 @@ const FilterMenu = ({ onChange, onApply, category }) => {
         pastScrimmage: ['conference', 'gameType', 'week', 'season'],
     }[category] || [];
 
-    const [pendingFilters, setPendingFilters] = useState({
-        filters: [],
-        sort: 'CLOSEST_TO_END',
-        conference: null,
-        season: null,
-        week: null,
-        gameType: null,
-        gameStatus: null,
-        page: 0,
-        size: 20,
-    });
+    const getSavedFilters = () => {
+        const saved = sessionStorage.getItem(`filters_${category}`);
+        if (!saved) {
+            return {
+                filters: [],
+                sort: 'CLOSEST_TO_END',
+                conference: null,
+                season: null,
+                week: null,
+                gameType: null,
+                gameStatus: null,
+                page: 0,
+                size: 10,
+            };
+        }
+
+        const parsed = JSON.parse(saved);
+        let { filters, gameStatus, gameType } = parsed;
+
+        // Extract gameStatus and gameType from filters if present
+        if (filters && Array.isArray(filters)) {
+            gameStatus = filters.find(f => ["PREGAME", "OPENING_KICKOFF", "IN_PROGRESS", "OVERTIME"].includes(f)) || null;
+            gameType = filters.find(f => ["OUT_OF_CONFERENCE", "CONFERENCE_GAME", "CONFERENCE_CHAMPIONSHIP", "PLAYOFFS", "NATIONAL_CHAMPIONSHIP", "BOWL"].includes(f)) || null;
+
+            // Remove extracted values from filters
+            filters = filters.filter(f => f !== gameStatus && f !== gameType);
+        }
+
+        return {
+            ...parsed,
+            filters,
+            gameStatus,
+            gameType,
+        };
+    };
+
+    const [pendingFilters, setPendingFilters] = useState(getSavedFilters);
+
+    useEffect(() => {
+        sessionStorage.setItem(`filters_${category}`, JSON.stringify(pendingFilters));
+    }, [pendingFilters, category]);
+
+    useEffect(() => {
+        const handleBeforeUnload = () => {
+            sessionStorage.removeItem(`filters_${category}`);
+        };
+
+        window.addEventListener("beforeunload", handleBeforeUnload);
+        return () => {
+            window.removeEventListener("beforeunload", handleBeforeUnload);
+        };
+    }, [category]);
 
     // Handle dropdown changes
     const handleChange = (field) => (event) => {
-        const newValue = event.target.value;
+        let newValue = event.target.value;
+        if (newValue === "") newValue = null; // Convert "All" to null
+
         setPendingFilters(prev => ({
             ...prev,
             [field]: newValue,
@@ -46,40 +89,38 @@ const FilterMenu = ({ onChange, onApply, category }) => {
     // Handle checkbox changes
     const handleCheckboxChange = (value) => (event) => {
         setPendingFilters(prev => {
-            const updatedFilters = [...prev.filters];
+            let updatedFilters = prev.filters.filter(f => f !== value);
+
             if (event.target.checked) {
-                if (!updatedFilters.includes(value)) {
-                    updatedFilters.push(value);
-                }
-            } else {
-                const index = updatedFilters.indexOf(value);
-                if (index > -1) {
-                    updatedFilters.splice(index, 1);
-                }
+                updatedFilters.push(value);
             }
+
             return { ...prev, filters: updatedFilters };
         });
     };
 
     // Apply filters when button is clicked
     const handleApply = () => {
-        let filters = pendingFilters.filters || [];
-        if (pendingFilters.gameType !== null) filters.push(pendingFilters.gameType)
-        if (pendingFilters.gameStatus !== null) filters.push(pendingFilters.gameStatus)
-        if (filters === []) filters = null
-        // Ensure filters is at least an empty array
+        let filters = [...pendingFilters.filters];
+
+        if (pendingFilters.gameType) filters.push(pendingFilters.gameType);
+        if (pendingFilters.gameStatus) filters.push(pendingFilters.gameStatus);
+
+        filters = [...new Set(filters)].filter(Boolean); // Remove duplicates and filter out null/undefined
+
         const finalFilters = {
-            filters: pendingFilters.filters || null, // Ensure filters is always an array
-            week: pendingFilters.week,
-            season: pendingFilters.season,
-            conference: pendingFilters.conference,
+            filters: filters.length > 0 ? filters : [],
+            week: pendingFilters.week || null,
+            season: pendingFilters.season || null,
+            conference: pendingFilters.conference || null,
             sort: pendingFilters.sort,
-            page: 0, // Reset to first page when filters change
-            size: 10, // Default page size
+            page: 0,
+            size: 10,
         };
 
-        onChange(finalFilters); // Send updated filters to parent
-        onApply(); // Close the menu
+        sessionStorage.setItem(`filters_${category}`, JSON.stringify(finalFilters));
+        onChange(finalFilters);
+        onApply();
     };
 
     return (
@@ -113,7 +154,15 @@ const FilterMenu = ({ onChange, onApply, category }) => {
                     value={pendingFilters.gameType || ""}
                     onChange={handleChange('gameType')}
                     label="Game Type"
-                />
+                >
+                    <MenuItem value="">All</MenuItem>
+                    <MenuItem value="OUT_OF_CONFERENCE">Out of Conference</MenuItem>
+                    <MenuItem value="CONFERENCE_GAME">Conference Game</MenuItem>
+                    <MenuItem value="CONFERENCE_CHAMPIONSHIP">Conference Championship</MenuItem>
+                    <MenuItem value="PLAYOFFS">Playoffs</MenuItem>
+                    <MenuItem value="NATIONAL_CHAMPIONSHIP">National Championship</MenuItem>
+                    <MenuItem value="BOWL">Bowl</MenuItem>
+                </GameTypeDropdown>
             )}
 
             {availableFilters.includes('gameStatus') && (
@@ -121,7 +170,13 @@ const FilterMenu = ({ onChange, onApply, category }) => {
                     value={pendingFilters.gameStatus || ""}
                     onChange={handleChange('gameStatus')}
                     label="Game Status"
-                />
+                >
+                    <MenuItem value="">All</MenuItem>
+                    <MenuItem value="PREGAME">Pregame</MenuItem>
+                    <MenuItem value="OPENING_KICKOFF">Opening Kickoff</MenuItem>
+                    <MenuItem value="IN_PROGRESS">In Progress</MenuItem>
+                    <MenuItem value="OVERTIME">Overtime</MenuItem>
+                </GameStatusDropdown>
             )}
 
             {availableFilters.includes('rankedGame') && (


### PR DESCRIPTION
This pull request includes several changes to the `ScorebugGrid` and `FilterMenu` components to improve pagination and filter handling. The most important changes involve updating the pagination logic, enhancing filter persistence using session storage, and refining the filter application process.

### Pagination and Filter Handling Improvements:

* [`src/components/game/ScorebugGrid.jsx`](diffhunk://#diff-fbfae31510a6ea63860b4240e50b6cd4bfa0163cdaf5e63d406d672d07f008b8L15-R15): Updated the pagination logic to assume 10 items per page instead of 20.

* `src/components/menu/FilterMenu.jsx`:
  * Added `useEffect` to handle side effects and session storage for filter persistence.
  * Introduced a function to retrieve saved filters from session storage and update the state accordingly.
  * Modified the filter state initialization to use the retrieved saved filters.
  * Enhanced the filter application logic to remove duplicates and filter out null/undefined values.
  * Added dropdown menu items for filter options such as game type and game status.