### PR TITLE
Fix Jenkins build, CFP logos, prod env config

### DIFF
--- a/Jenkinsfile_PRD
+++ b/Jenkinsfile_PRD
@@ -27,6 +27,7 @@ pipeline {
                         REACT_APP_CLIENT_SECRET=${CLIENT_SECRET}
                         REACT_APP_BASE_URL=https://api.fakecollegefootball.com/api/v1/arceus/discord/redirect
                         REACT_APP_API_BASE_URL=https://api.fakecollegefootball.com/api/v1/arceus
+                        REACT_APP_API_URL=https://api.fakecollegefootball.com
                         EOF
                     """
                 }

--- a/src/components/constants/playoffBracket.js
+++ b/src/components/constants/playoffBracket.js
@@ -1,5 +1,8 @@
 // ─── Playoff Bracket Constants ────────────────────────────────────────
 
+// Official CFP logo
+export const CFP_LOGO_URL = 'https://am-prod-client-files.ppub-tmaws.io/cfbplayoff/s3fs-public/CFP%20Symbol%20Gold%20PMS%20Dark%20BG.PNG';
+
 // R2 bye seeds in bracket position order (byeSeed + r1HighSeed = 17)
 // This defines which bye team (seeds 1-8) faces which R1 winner in Round 2
 export const R2_BYE_SEEDS = [1, 8, 4, 5, 3, 6, 2, 7];

--- a/src/components/game/scoreboard/LiveGameCard.jsx
+++ b/src/components/game/scoreboard/LiveGameCard.jsx
@@ -20,10 +20,11 @@ const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:1313';
 const GameTypeInfo = ({ game, homeTeamData }) => {
     const theme = useTheme();
     const gameType = game.game_type;
-    const postseasonLogo = game.postseason_game_logo
-        ? `${API_BASE}/images/${game.postseason_game_logo}`
+    const rawLogo = game.postseason_game_logo;
+    const postseasonLogo = rawLogo
+        ? (rawLogo.startsWith('http') ? rawLogo : `${API_BASE}/images/${rawLogo}`)
         : null;
-    const bowlName = game.bowl_game_name;
+    const bowlName = game.postseason_game_name;
     const confData = homeTeamData?.conference
         ? conferences.find(c => c.value === homeTeamData.conference)
         : null;

--- a/src/components/schedule/Postseason.jsx
+++ b/src/components/schedule/Postseason.jsx
@@ -497,10 +497,10 @@ const Postseason = ({
 
     // ── Derive Bowl card header info ─────────────────────────────────
     const getBowlHeaderInfo = (game) => {
-        const bowlName = field(game, 'bowlGameName', 'bowl_game_name');
+        const bowlName = field(game, 'postseasonGameName', 'postseason_game_name');
         const gameLogo = field(game, 'postseasonGameLogo', 'postseason_game_logo');
         const logoUrl = gameLogo
-            ? `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${gameLogo}`
+            ? (gameLogo.startsWith('http') ? gameLogo : `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${gameLogo}`)
             : null;
         return {
             logo: logoUrl,

--- a/src/components/schedule/TeamScheduleTable.jsx
+++ b/src/components/schedule/TeamScheduleTable.jsx
@@ -238,7 +238,7 @@ const TeamScheduleTable = ({
                                                   field(game, 'postseasonGameLogo', 'postseason_game_logo') && (
                                                     <Box sx={{ display: 'flex', justifyContent: 'center', mb: 0.5 }}>
                                                         <Avatar
-                                                            src={`${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${field(game, 'postseasonGameLogo', 'postseason_game_logo')}`}
+                                                            src={(() => { const logo = field(game, 'postseasonGameLogo', 'postseason_game_logo'); return logo.startsWith('http') ? logo : `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${logo}`; })()}
                                                             sx={{ width: 40, height: 40 }}
                                                             variant="rounded"
                                                         />

--- a/src/components/scheduling/PostseasonAdminTab.jsx
+++ b/src/components/scheduling/PostseasonAdminTab.jsx
@@ -34,7 +34,7 @@ import { createScheduleEntry, updateScheduleEntry, deleteScheduleEntry } from '.
 import { uploadPostseasonLogo } from '../../api/uploadApi';
 import { conferences } from '../constants/conferences';
 import Postseason from '../schedule/Postseason';
-import { R2_BYE_SEEDS, ROUND_LABELS, playoffWeekForRound } from '../constants/playoffBracket';
+import { R2_BYE_SEEDS, ROUND_LABELS, playoffWeekForRound, CFP_LOGO_URL } from '../constants/playoffBracket';
 import { field } from '../../utils/fieldHelper';
 
 // Conferences available for CCG (exclude FBS Independent)
@@ -225,11 +225,11 @@ const PostseasonAdminTab = ({
     // ── Edit bowl game name ──────────────────────────────────────────
     const handleEditBowlName = (game) => {
         setEditingBowlGame(game);
-        setEditingBowlName(field(game, 'bowlGameName', 'bowl_game_name') || '');
+        setEditingBowlName(field(game, 'postseasonGameName', 'postseason_game_name') || '');
         const logoUrl = field(game, 'postseasonGameLogo', 'postseason_game_logo');
         setEditingBowlLogo(logoUrl || null);
         if (logoUrl) {
-            setEditingBowlLogoPreview(`${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${logoUrl}`);
+            setEditingBowlLogoPreview(logoUrl.startsWith('http') ? logoUrl : `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${logoUrl}`);
         } else {
             setEditingBowlLogoPreview(null);
         }
@@ -246,7 +246,7 @@ const PostseasonAdminTab = ({
                 homeTeam: field(editingBowlGame, 'homeTeam', 'home_team'),
                 awayTeam: field(editingBowlGame, 'awayTeam', 'away_team'),
                 gameType: field(editingBowlGame, 'gameType', 'game_type'),
-                bowlGameName: editingBowlName || null,
+                postseasonGameName: editingBowlName || null,
                 postseasonGameLogo: editingBowlLogo || null,
             });
             onShowSnackbar('Bowl game updated successfully');
@@ -300,6 +300,8 @@ const PostseasonAdminTab = ({
                     playoffRound: 1,
                     playoffHomeSeed: highSeed,
                     playoffAwaySeed: lowSeed,
+                    postseasonGameLogo: CFP_LOGO_URL,
+                    postseasonGameName: ROUND_LABELS[1],
                 });
             }
 
@@ -317,6 +319,8 @@ const PostseasonAdminTab = ({
                     playoffRound: 2,
                     playoffHomeSeed: byeSeed,
                     playoffAwaySeed: null,
+                    postseasonGameLogo: CFP_LOGO_URL,
+                    postseasonGameName: ROUND_LABELS[2],
                 });
             }
 
@@ -371,6 +375,8 @@ const PostseasonAdminTab = ({
                         playoffRound: 2,
                         playoffHomeSeed: byeSeed,
                         playoffAwaySeed: winnerSeed,
+                        postseasonGameLogo: CFP_LOGO_URL,
+                        postseasonGameName: ROUND_LABELS[2],
                     });
                     onShowSnackbar(`${advanceWinner} (#${winnerSeed}) advances to face #${byeSeed} in ${ROUND_LABELS[2]} (Week ${nextWeek})!`);
                     setAdvanceDialogOpen(false);
@@ -490,6 +496,8 @@ const PostseasonAdminTab = ({
                     playoffRound: nextRound,
                     playoffHomeSeed: isPlaceholder(h) ? winnerSeed : existingHomeSeed,
                     playoffAwaySeed: isPlaceholder(a) ? winnerSeed : existingAwaySeed,
+                    postseasonGameLogo: CFP_LOGO_URL,
+                    postseasonGameName: ROUND_LABELS[nextRound],
                 });
                 onShowSnackbar(`${advanceWinner} advanced to ${ROUND_LABELS[nextRound] || `Round ${nextRound}`} (Week ${nextWeek})!`);
             } else {
@@ -503,6 +511,8 @@ const PostseasonAdminTab = ({
                     playoffRound: nextRound,
                     playoffHomeSeed: winnerSeed,
                     playoffAwaySeed: null,
+                    postseasonGameLogo: CFP_LOGO_URL,
+                    postseasonGameName: ROUND_LABELS[nextRound],
                 });
                 onShowSnackbar(`${advanceWinner} advanced to ${ROUND_LABELS[nextRound] || `Round ${nextRound}`} (Week ${nextWeek})!`);
             }
@@ -585,7 +595,7 @@ const PostseasonAdminTab = ({
                                         {field(game, 'postseasonGameLogo', 'postseason_game_logo') && (
                                             <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
                                                 <Avatar
-                                                    src={`${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${field(game, 'postseasonGameLogo', 'postseason_game_logo')}`}
+                                                    src={(() => { const logo = field(game, 'postseasonGameLogo', 'postseason_game_logo'); return logo.startsWith('http') ? logo : `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${logo}`; })()}
                                                     sx={{ width: 80, height: 80 }}
                                                     variant="rounded"
                                                 />
@@ -662,7 +672,7 @@ const PostseasonAdminTab = ({
                                 const started = field(game, 'started', 'started');
                                 const homeScore = field(game, 'homeScore', 'home_score');
                                 const awayScore = field(game, 'awayScore', 'away_score');
-                                const bowlName = field(game, 'bowlGameName', 'bowl_game_name');
+                                const bowlName = field(game, 'postseasonGameName', 'postseason_game_name');
                                 const homeWon = finished && homeScore != null && homeScore > awayScore;
                                 const awayWon = finished && awayScore != null && awayScore > homeScore;
                                 return (
@@ -671,7 +681,7 @@ const PostseasonAdminTab = ({
                                         {field(game, 'postseasonGameLogo', 'postseason_game_logo') && (
                                             <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
                                                 <Avatar
-                                                    src={`${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${field(game, 'postseasonGameLogo', 'postseason_game_logo')}`}
+                                                    src={(() => { const logo = field(game, 'postseasonGameLogo', 'postseason_game_logo'); return logo.startsWith('http') ? logo : `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${logo}`; })()}
                                                     sx={{ width: 80, height: 80 }}
                                                     variant="rounded"
                                                 />

--- a/src/pages/admin/Scheduling.jsx
+++ b/src/pages/admin/Scheduling.jsx
@@ -422,7 +422,7 @@ const Scheduling = () => {
                 playoffRound: addGamePlayoffRound,
                 playoffHomeSeed: addGameHomeSeed,
                 playoffAwaySeed: addGameAwaySeed,
-                bowlGameName: addGameType === 'BOWL' ? addGameBowlName : null,
+                postseasonGameName: addGameType === 'BOWL' ? addGameBowlName : null,
                 postseasonGameLogo: (addGameType === 'BOWL' || addGameType === 'PLAYOFFS' || addGameType === 'CONFERENCE_CHAMPIONSHIP' || addGameType === 'NATIONAL_CHAMPIONSHIP') ? addGameLogo : null,
             });
             showSnackbar('Game added successfully');

--- a/src/pages/game/GameDetails.jsx
+++ b/src/pages/game/GameDetails.jsx
@@ -342,7 +342,7 @@ const GameDetails = ({ isAdmin }) => {
                 {game?.postseason_game_logo && (game?.game_type === 'BOWL' || game?.game_type === 'PLAYOFFS' || game?.game_type === 'CONFERENCE_CHAMPIONSHIP' || game?.game_type === 'NATIONAL_CHAMPIONSHIP') && (
                     <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
                         <Avatar
-                            src={`${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${game.postseason_game_logo}`}
+                            src={game.postseason_game_logo.startsWith('http') ? game.postseason_game_logo : `${process.env.REACT_APP_API_URL || 'http://localhost:1313'}/images/${game.postseason_game_logo}`}
                             sx={{ width: 120, height: 120 }}
                             variant="rounded"
                         />


### PR DESCRIPTION
## Summary
- Fix Docker build OOM: multi-stage build, disable sourcemaps, add .dockerignore, upgrade to Node 20
- Add CFP logo for all playoff game creation/advancement
- Set postseasonGameName for playoff rounds
- Add REACT_APP_API_URL to Jenkinsfile_PRD for image serving
- Rename bowlGameName to postseasonGameName throughout
- Handle external URLs for postseason logos
- Remove unused QuarterScoreTable, redundant WP chart ReferenceLine, bracket header gradient

## Test plan
- [ ] Verify Jenkins build completes successfully
- [ ] Verify prod connects to correct API
- [ ] Verify postseason logos display correctly
- [ ] Verify playoff bracket creation sets CFP logo and round names

🤖 Generated with [Claude Code](https://claude.com/claude-code)